### PR TITLE
Add Weekly Allocated Hours metric

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,6 +244,10 @@
                             <h4>Effective AHT per Task</h4>
                             <div class="metric-value" id="effectiveAHT">0.37</div>
                         </div>
+                        <div class="metric-card">
+                            <h4>Weekly Allocated Hours</h4>
+                            <div class="metric-value" id="weeklyAllocatedHours">0</div>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add new metric Weekly Allocated Hours
- show weekly hours values on Overview tab
- export weekly hours in CSV

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_684ab21839388332b99e93d48d3a16b0