### PR TITLE
Add dynamic AHT calc and slider input styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -286,9 +286,16 @@ class RampPlanningApp {
         const peakCBs = Math.ceil(peakDailyHours / config.dailyHours);
         
         // Calculate effective AHT
-        const effectiveAHT =
-            (l1Hours + l0Hours + l1StageHours + l4StageHours + l10StageHours + l12StageHours) /
-            config.targetTasks;
+        const layerAHTMap = {
+            '-1': config.l1AHT,
+            '0': config.l0AHT,
+            '1': config.l1StageAHT,
+            '4': config.l4StageAHT,
+            '10': config.l10StageAHT,
+            '12': config.l12StageAHT
+        };
+        const effectiveAHT = this.config.activeLayers
+            .reduce((sum, layer) => sum + (layerAHTMap[layer] || 0), 0);
         
         // Bonus mission costs
         const selectedWebinarCost = config.webinarDuration === 30 ? config.cost30min : config.cost60min;

--- a/style.css
+++ b/style.css
@@ -897,6 +897,11 @@ body {
   width: 70px;
 }
 
+/* Ensure dynamically added inputs in sliders match */
+.slider-container input[type="number"] {
+  width: 70px;
+}
+
 /* Radio Groups */
 .radio-group {
   display: flex;


### PR DESCRIPTION
## Summary
- compute Effective AHT per Task based on selected layers only
- keep slider number inputs consistent in style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d7afd79708332aa48f36851fa2cb3